### PR TITLE
pre-commit: test meta hooks

### DIFF
--- a/pkgs/tools/misc/pre-commit/default.nix
+++ b/pkgs/tools/misc/pre-commit/default.nix
@@ -178,8 +178,8 @@ buildPythonApplication rec {
     "pre_commit"
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = pre-commit;
+  passthru.tests = callPackage ./tests.nix {
+    inherit git pre-commit;
   };
 
   meta = with lib; {

--- a/pkgs/tools/misc/pre-commit/tests.nix
+++ b/pkgs/tools/misc/pre-commit/tests.nix
@@ -1,0 +1,37 @@
+{ git
+, pre-commit
+, runCommand
+, testers
+}: {
+  check-meta-hooks = runCommand "check-meta-hooks" {
+    nativeBuildInputs = [ git pre-commit ];
+  } ''
+    cd "$(mktemp --directory)"
+    export HOME="$PWD"
+    cat << 'EOF' > .pre-commit-config.yaml
+    repos:
+      - repo: local
+        hooks:
+          - id: echo
+            name: echo
+            entry: echo
+            files: \.yaml$
+            language: system
+      - repo: meta
+        hooks:
+          - id: check-hooks-apply
+          - id: check-useless-excludes
+          - id: identity
+    EOF
+    git config --global user.email "you@example.com"
+    git config --global user.name "Your Name"
+    git init --initial-branch=main
+    git add .
+    pre-commit run --all-files
+    touch $out
+  '';
+
+  version = testers.testVersion {
+    package = pre-commit;
+  };
+}


### PR DESCRIPTION
###### Description of changes

Closes #270805 by verifying that #251418 fixes the issue.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).